### PR TITLE
Adding main entry in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "typings": "dist/esm/index.d.ts",
   "unpkg": "dist/umd/pushin.min.js",
   "exports": {
+    ".": "./dist/umd/pushin.js",
     "./pushin.css": {
       "style": "./dist/pushin.css"
     }


### PR DESCRIPTION
Hi @nateplusplus,
I recently bumped in a issue while using this library in a NextJS project. The compiler is complaining about the main script entry being missing from the exports.
<img width="765" alt="Screen Shot 2022-05-13 at 12 34 53" src="https://user-images.githubusercontent.com/1532277/168266292-7ceff6dc-fbaa-4c4a-88bd-8ddb10f4b3da.png">

[Here is a reproducer](https://github.com/liarco/pushin-nextjs-reproducer) to quickly verify the issue, as you can see from [this commit](https://github.com/liarco/pushin-nextjs-reproducer/commit/6e0f8498564a516199acda629eb4a3c041cfb444) I simply implemented the demo found on your readme.

Am I missing anything here? If my reproducer is implemented correctly, then I found the changes in this PR to successfully fix the issue, but tbh I have no experience with this `exports` setting so you may find a better solution for this.

Thank you for your time, please let me know if you need any further information about this.

### Temporary patched package

For anyone experiencing this issue, I published a temporary patch package: https://github.com/liarco/pushin/packages/1420214 (this will be removed as soon as the issue is fixed)